### PR TITLE
Fixed problem with region

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ module.exports = Class.extend({
 
    subscribeFunction: function(fnName, fnDef, topicName) {
       var self = this,
-          sns = new AWS.SNS();
+          sns = new AWS.SNS({ region: this._serverless.service.defaults.region });
 
       if (this._opts.noDeploy) {
          return this._serverless.cli.log(
@@ -87,7 +87,7 @@ module.exports = Class.extend({
 
    unsubscribeFunction: function(fnName, fnDef, topicName) {
       var self = this,
-          sns = new AWS.SNS();
+          sns = new AWS.SNS({ region: this._serverless.service.defaults.region });
 
       this._serverless.cli.log('Need to unsubscribe ' + fnDef.name + ' from ' + topicName);
 
@@ -109,8 +109,8 @@ module.exports = Class.extend({
 
    _getSubscriptionInfo: function(fnName, fnDef, topicName) {
       var self = this,
-          sns = new AWS.SNS(),
-          lambda = new AWS.Lambda(),
+          sns = new AWS.SNS({ region: this._serverless.service.defaults.region }),
+          lambda = new AWS.Lambda({ region: this._serverless.service.defaults.region }),
           fnArn, acctID, region, topicArn;
 
       return Q.ninvoke(lambda, 'getFunction', { FunctionName: fnDef.name })


### PR DESCRIPTION
When I try run deploy I see next error:
```
 
  Config Error -------------------------------------------
 
     Missing region in config
 
     For debugging logs, run again after setting SLS_DEBUG env var.
 
  Stack Trace --------------------------------------------
 
ConfigError: Missing region in config
  at Request.VALIDATE_REGION (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/event_listeners.js:81:45)
  at Request.callListeners (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
  at callNextListener (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
  at /home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/event_listeners.js:75:9
  at finish (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/config.js:308:7)
  at /home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/config.js:324:9
  at SharedIniFileCredentials.get (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/credentials.js:126:7)
  at getAsyncCredentials (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/config.js:318:24)
  at Config.getCredentials (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/config.js:338:9)
  at Request.VALIDATE_CREDENTIALS (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/event_listeners.js:70:26)
  at Request.callListeners (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/sequential_executor.js:101:18)
  at Request.emit (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
  at Request.emit (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/request.js:668:14)
  at Request.transition (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/request.js:22:10)
  at AcceptorStateMachine.runTo (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/state_machine.js:14:12)
  at Request.runTo (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/request.js:394:15)
  at Request.send (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/request.js:358:10)
  at [object Object].makeRequest (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/service.js:193:27)
  at [object Object].svc.(anonymous function) [as getFunction] (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/aws-sdk/lib/service.js:451:23)
  at Promise.post (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/q/q.js:1161:36)
  at Promise.promise.promiseDispatch (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/q/q.js:788:41)
  at /home/nas/projects/atb-custom.ecommerce.customer/node_modules/q/q.js:1391:14
  at runSingle (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/q/q.js:137:13)
  at flush (/home/nas/projects/atb-custom.ecommerce.customer/node_modules/q/q.js:125:13)
  at nextTickCallbackWith0Args (node.js:419:9)
  at process._tickDomainCallback (node.js:389:13)
```
It's problem will be resolved after my changes.
@jthomerson Please take my pull request.