### PR TITLE
Add SourceArn to Lambda perms

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "istanbul": "0.4.4",
     "mocha": "3.0.2",
     "mocha-lcov-reporter": "1.2.0",
+    "serverless": "1.2.1",
     "sinon": "1.17.5"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ module.exports = Class.extend({
             FunctionName: { 'Fn::GetAtt': [ fnRef, 'Arn' ] },
             Action: 'lambda:InvokeFunction',
             Principal: 'sns.amazonaws.com',
+            SourceArn: { 'Fn::Join': [ ':', [ 'arn:aws:sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, topicName ] ] }
          },
       };
 

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -1,14 +1,31 @@
 'use strict';
 
 var expect = require('expect.js'),
-    Plugin = require('../index.js');
+    Plugin = require('../index.js'),
+    Serverless = require('serverless');
 
 describe('serverless-plugin-external-sns-events', function() {
 
    describe('addEventPermission', function() {
+      var plugin, resources, serverless;
 
-      // TODO: write tests
+      serverless = new Serverless();
+      serverless.service.provider.compiledCloudFormationTemplate = {
+         Resources: {},
+      };
 
+      plugin = new Plugin(serverless);
+
+      plugin.addEventPermission('someFunction', undefined, 'someTopic');
+      resources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+      it('populates Serverless compiledCloudFormationTemplate resources with permission SomeFunctionLambdaPermissionSomeTopic', function() {
+         expect(resources).to.only.have.key('SomeFunctionLambdaPermissionSomeTopic');
+      });
+
+      it('populates permission object with SourceArn', function() {
+         expect(resources.SomeFunctionLambdaPermissionSomeTopic.Properties).to.have.key('SourceArn');
+      });
    });
 
 


### PR DESCRIPTION
Adds `SourceArn` attribute to the `AWS::Lambda::Permission` resource. Amazon adds this field to the permission when subscribing Lambda to SNS through the web interface. Adding it here gets the web panel working as expected.

Fixes #5 