### PR TITLE
Use built-in SLS provider for AWS SDK, fix Lambda permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,8 @@ functions:
 By doing that, the `deploy` and `remove` commands in SLS will now subscribe and
 unsubscribe your function to or from the specified topic. If you would like to
 subscribe or unsubscribe the functions manually (outside of a deploy or remove
-command), you can use `sls subscribeExternalSNS` or
-`sls unsubscribeExternalSNS`.
-
-**NOTE:** This plugin requires the AWS SDK (`require('aws-sdk')`), but does not
-list it as a dependency. This allows you to provide the dependency your own
-way, making sure not to bundle the SDK and all its dependencies with your
-function code.
+command), you can use `serverless subscribeExternalSNS` or
+`serverless unsubscribeExternalSNS`.
 
 
 ## How do I contribute?

--- a/package.json
+++ b/package.json
@@ -25,11 +25,9 @@
   "homepage": "https://github.com/silvermine/serverless-plugin-external-sns-events#readme",
   "dependencies": {
     "class.extend": "0.9.2",
-    "q": "1.4.1",
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "aws-sdk": "2.6.9",
     "coveralls": "2.11.12",
     "eslint": "3.3.1",
     "eslint-config-silvermine": "1.0.0",
@@ -39,6 +37,7 @@
     "istanbul": "0.4.4",
     "mocha": "3.0.2",
     "mocha-lcov-reporter": "1.2.0",
-    "sinon": "1.17.5"
+    "sinon": "1.17.5",
+    "q": "1.4.1"
   }
 }

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -1,16 +1,369 @@
 'use strict';
 
 var expect = require('expect.js'),
-    Plugin = require('../index.js');
+    Plugin = require('../index.js'),
+    Q = require('q'),
+    sinon = require('sinon');
 
 describe('serverless-plugin-external-sns-events', function() {
 
+   function createMockServerless(requestFunc) {
+      var serverless, provider;
+
+      provider = {
+         request: requestFunc
+      };
+
+      serverless = {
+         getProvider: function(providerName) {
+            if (providerName !== 'aws') {
+               return null;
+            }
+
+            return provider;
+         },
+         service: {
+            provider: {
+               compiledCloudFormationTemplate: {
+                  Resources: {}
+               }
+            }
+         },
+         cli: { log: function() {
+            return;
+         } },
+      };
+      return serverless;
+   }
+
+   function createMockRequest(requestStub) {
+      return function() {
+         var reqArgs = Array.prototype.slice.call(arguments);
+
+         return Q.promise(function(resolve, reject) {
+            var result = requestStub.apply(undefined, reqArgs);
+
+            if (result !== null) {
+               resolve(result);
+               return;
+            }
+
+            reject(new Error('Call to request() with unexpected arguments:  ' + JSON.stringify(reqArgs)));
+         });
+      };
+   }
+
+   function isPromise(obj) {
+      return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+   }
+
    describe('addEventPermission', function() {
 
-      // TODO: write tests
+      it('can compile lambda permission with correct FunctionName and SourceArn', function() {
+         var topicName = 'cool-Topic',
+             functionName = 'myFunc',
+             mockServerless = createMockServerless(createMockRequest(sinon.stub())),
+             spyRequestFunc = sinon.spy(mockServerless.getProvider('aws'), 'request'),
+             plugin = new Plugin(mockServerless, {}),
+             expPerm, expResourceName, actualPerm;
+
+         plugin.addEventPermission(functionName, { name: functionName }, topicName);
+
+         expect(spyRequestFunc.callCount).to.be(0);
+         expect(Object.keys(mockServerless.service.provider.compiledCloudFormationTemplate.Resources).length).to.be(1);
+
+         expResourceName = 'MyFuncLambdaPermissionCoolTopic';
+
+         expect(expResourceName in mockServerless.service.provider.compiledCloudFormationTemplate.Resources).to.be(true);
+
+         actualPerm = mockServerless.service.provider.compiledCloudFormationTemplate.Resources[expResourceName];
+
+         expPerm = {
+            Type: 'AWS::Lambda::Permission',
+            Properties: {
+               FunctionName: { 'Fn::GetAtt': [ 'MyFuncLambdaFunction', 'Arn' ] },
+               Action: 'lambda:InvokeFunction',
+               Principal: 'sns.amazonaws.com',
+               SourceArn: { 'Fn::Join': [ ':', [ 'arn:aws:sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, 'cool-Topic' ] ] }
+            },
+         };
+
+         expect(actualPerm).to.eql(expPerm);
+      });
 
    });
 
+   describe('_getSubscriptionInfo', function() {
+
+      it('can return SNS Subscription info when subscription exists', function() {
+         var account = '12349',
+             topicName = 'cooltopic',
+             functionName = 'myFunc',
+             stage = 'test1',
+             region = 'us-west-42',
+             subscriptionArn = 'arn:aws:sns:correct',
+             lambdaArn = 'arn:aws:lambda:' + region + ':' + account + ':function:' + functionName,
+             topicArn = 'arn:aws:sns:' + region + ':' + account + ':' + topicName,
+             requestStub = sinon.stub(),
+             mockServerless, requestMethod, actual, plugin;
+
+         requestStub.withArgs('Lambda', 'getFunction', { FunctionName: functionName }, stage, region)
+            .returns({ Configuration: { FunctionArn: lambdaArn } });
+
+         requestStub.withArgs('SNS', 'listSubscriptionsByTopic', { TopicArn: topicArn }, stage, region)
+            .returns({
+               Subscriptions: [
+                  { Protocol: 'other', Endpoint: lambdaArn, SubscriptionArn: 'junk' },
+                  { Protocol: 'lambda', Endpoint: lambdaArn, SubscriptionArn: subscriptionArn },
+                  { Protocol: 'lambda', Endpoint: 'wronglambda', SubscriptionArn: 'junksub' },
+               ]
+            });
+
+         mockServerless = createMockServerless(createMockRequest(requestStub));
+
+         requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request');
+
+         plugin = new Plugin(mockServerless, { stage: stage, region: region });
+
+         actual = plugin._getSubscriptionInfo({ name: functionName }, topicName);
+
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function(result) {
+            expect(requestMethod.callCount).to.be(2);
+            expect(result).to.eql({
+               FunctionArn: lambdaArn,
+               TopicArn: topicArn,
+               SubscriptionArn: subscriptionArn
+            });
+         });
+      });
+
+      it('can return undefined Subscription info when subscription does NOT exist', function() {
+         var account = '12349',
+             topicName = 'cooltopic',
+             functionName = 'myFunc',
+             stage = 'test1',
+             region = 'us-west-42',
+             lambdaArn = ('arn:aws:lambda:' + region + ':' + account + ':function:' + functionName),
+             topicArn = ('arn:aws:sns:' + region + ':' + account + ':' + topicName),
+             requestStub = sinon.stub(),
+             mockServerless, requestMethod, actual, plugin;
+
+         requestStub.withArgs('Lambda', 'getFunction', { FunctionName: functionName }, stage, region)
+            .returns({ Configuration: { FunctionArn: lambdaArn } });
+
+         requestStub.withArgs('SNS', 'listSubscriptionsByTopic', { TopicArn: topicArn }, stage, region)
+            .returns({
+               Subscriptions: [
+                  { Protocol: 'other', Endpoint: lambdaArn, SubscriptionArn: 'junk' },
+                  { Protocol: 'lambda', Endpoint: 'wronglambda', SubscriptionArn: 'junksub' },
+               ]
+            });
+
+         mockServerless = createMockServerless(createMockRequest(requestStub));
+         requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request');
+         plugin = new Plugin(mockServerless, { stage: stage, region: region });
+
+         actual = plugin._getSubscriptionInfo({ name: functionName }, topicName);
+
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function(result) {
+            expect(requestMethod.callCount).to.be(2);
+            expect(result).to.eql({
+               FunctionArn: lambdaArn,
+               TopicArn: topicArn,
+               SubscriptionArn: undefined
+            });
+         });
+      });
+
+   });
+
+   describe('subscribeFunction', function() {
+
+      it('can exit early when noDeploy is true', function() {
+         var stage = 'test1',
+             region = 'us-west-42',
+             topicName = 'cooltopic',
+             functionName = 'myFunc',
+             requestStub = sinon.stub(),
+             mockServerless = createMockServerless(createMockRequest(requestStub)),
+             requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request'),
+             plugin = new Plugin(mockServerless, { stage: stage, region: region, noDeploy: true }),
+             spyGetSubscriptionInfo = sinon.spy(plugin, '_getSubscriptionInfo'),
+             actual = plugin.subscribeFunction(functionName, { name: functionName }, topicName);
+
+         expect(isPromise(actual)).to.be(false);
+         expect(actual).to.be(undefined);
+         expect(spyGetSubscriptionInfo.callCount).to.be(0);
+         expect(requestMethod.callCount).to.be(0);
+      });
+
+      it('will not add the subscription if it already exists', function() {
+         var stage = 'test1',
+             region = 'us-west-42',
+             topicName = 'cooltopic',
+             functionName = 'myFunc',
+             requestStub = sinon.stub(),
+             mockServerless = createMockServerless(createMockRequest(requestStub)),
+             requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request'),
+             plugin = new Plugin(mockServerless, { stage: stage, region: region, noDeploy: false }),
+             funcDef = { name: functionName },
+             actual, stubGetSubscriptionInfo;
+
+         stubGetSubscriptionInfo = sinon.stub(plugin, '_getSubscriptionInfo', function() {
+            return Q({
+               FunctionArn: 'some-func-arn',
+               TopicArn: 'some-topic-arn',
+               SubscriptionArn: 'subscription-arn-here',
+            });
+         });
+
+         actual = plugin.subscribeFunction(functionName, funcDef, topicName);
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function(result) {
+            expect(stubGetSubscriptionInfo.callCount).to.be(1);
+            expect(stubGetSubscriptionInfo.calledWithExactly(funcDef, topicName)).to.be(true);
+
+            // Since we mocked getSubscriptionInfo and added a fake SubscriptionArn
+            // then no subsequent requests should have been made to the provider.
+            expect(requestMethod.callCount).to.be(0);
+
+            expect(result).to.be(undefined);
+         });
+      });
+
+      it('can add the subscription if it does NOT exist', function() {
+         var stage = 'test1',
+             region = 'us-west-42',
+             topicName = 'cooltopic',
+             functionName = 'myFunc',
+             requestStub = sinon.stub(),
+             mockServerless = createMockServerless(createMockRequest(requestStub)),
+             requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request'),
+             plugin = new Plugin(mockServerless, { stage: stage, region: region, noDeploy: false }),
+             funcDef = { name: functionName },
+             actual, stubGetSubscriptionInfo, expSub;
+
+         stubGetSubscriptionInfo = sinon.stub(plugin, '_getSubscriptionInfo', function() {
+            return Q({
+               FunctionArn: 'some-func-arn',
+               TopicArn: 'some-topic-arn',
+               SubscriptionArn: undefined
+            });
+         });
+
+         actual = plugin.subscribeFunction(functionName, funcDef, topicName);
+
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function(result) {
+            expect(stubGetSubscriptionInfo.callCount).to.be(1);
+            expect(stubGetSubscriptionInfo.calledWithExactly(funcDef, topicName)).to.be(true);
+
+            // Since we mocked getSubscriptionInfo then we will only expect
+            // a single call to request, that is to add the subscription.
+            expect(requestMethod.callCount).to.be(1);
+
+            expSub = {
+               TopicArn: 'some-topic-arn',
+               Protocol: 'lambda',
+               Endpoint: 'some-func-arn'
+            };
+
+            expect(requestMethod.calledWithExactly('SNS', 'subscribe', expSub, stage, region))
+               .to
+               .be(true);
+
+            expect(result).to.be(undefined);
+         });
+      });
+
+   });
+
+   describe('unsubscribeFunction', function() {
+
+      it('will not unsubscribe if subscription does not exist', function() {
+         var stage = 'test1',
+             region = 'us-west-42',
+             topicName = 'cooltopic',
+             functionName = 'myFunc',
+             requestStub = sinon.stub(),
+             mockServerless = createMockServerless(createMockRequest(requestStub)),
+             requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request'),
+             plugin = new Plugin(mockServerless, { stage: stage, region: region, noDeploy: false }),
+             funcDef = { name: functionName },
+             actual, stubGetSubscriptionInfo;
+
+         stubGetSubscriptionInfo = sinon.stub(plugin, '_getSubscriptionInfo', function() {
+            return Q({
+               FunctionArn: 'some-func-arn',
+               TopicArn: 'some-topic-arn',
+               SubscriptionArn: undefined
+            });
+         });
+
+         actual = plugin.unsubscribeFunction(functionName, funcDef, topicName);
+
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function() {
+            expect(stubGetSubscriptionInfo.callCount).to.be(1);
+            expect(stubGetSubscriptionInfo.calledWithExactly(funcDef, topicName)).to.be(true);
+
+            // Since we mocked getSubscriptionInfo to find no existing
+            // subscriptions then we will not expect any direct calls to
+            // the request method.
+            expect(requestMethod.callCount).to.be(0);
+         });
+      });
+
+      it('can unsubscribe if subscription exist', function() {
+         var stage = 'test1',
+             region = 'us-west-42',
+             topicName = 'cooltopic',
+             functionName = 'myFunc',
+             requestStub = sinon.stub(),
+             mockServerless = createMockServerless(createMockRequest(requestStub)),
+             requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request'),
+             plugin = new Plugin(mockServerless, { stage: stage, region: region, noDeploy: false }),
+             funcDef = { name: functionName },
+             stubGetSubscriptionInfo, actual, params;
+
+         stubGetSubscriptionInfo = sinon.stub(plugin, '_getSubscriptionInfo', function() {
+            return Q({
+               FunctionArn: 'some-func-arn',
+               TopicArn: 'some-topic-arn',
+               SubscriptionArn: 'some-subscription-arn'
+            });
+         });
+
+         actual = plugin.unsubscribeFunction(functionName, funcDef, topicName);
+
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function() {
+            expect(stubGetSubscriptionInfo.callCount).to.be(1);
+            expect(stubGetSubscriptionInfo.calledWithExactly(funcDef, topicName)).to.be(true);
+
+            // Since we mocked getSubscriptionInfo we should
+            // only have one call to the request (to remove the subscription)
+            expect(requestMethod.callCount).to.be(1);
+
+            params = {
+               SubscriptionArn: 'some-subscription-arn'
+            };
+
+            expect(requestMethod.calledWithExactly('SNS', 'unsubscribe', params, stage, region))
+               .to
+               .be(true);
+         });
+      });
+
+   });
 
    describe('_normalize', function() {
       var plugin = new Plugin();


### PR DESCRIPTION
 * Changed plugin to use built-in serverless provider.request for AWS SDK calls.
 * Removed dependency on AWS SDK
 * Added SourceArn so Lambda to AWS permission so it's more secure.
   * This will also allow it to display in the Triggers tab in the Lambda console.
 * Added additional Unit Tests for better coverage.