### PR TITLE
feat: support govcloud and china regions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ module.exports = Class.extend({
             FunctionName: { 'Fn::GetAtt': [ fnRef, 'Arn' ] },
             Action: 'lambda:InvokeFunction',
             Principal: 'sns.amazonaws.com',
-            SourceArn: { 'Fn::Join': [ ':', [ 'arn:aws:sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, topicName ] ] },
+            SourceArn: { 'Fn::Join': [ ':', [ 'arn:', { 'Ref': 'AWS::Partition' },':sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, topicName ] ] },
          },
       };
 
@@ -129,9 +129,10 @@ module.exports = Class.extend({
             fnArn = fn.Configuration.FunctionArn;
             // NOTE: assumes that the topic is in the same account and region at this
             // point
+            let partition = fnArn.split(':')[1];
             region = fnArn.split(':')[3];
             acctID = fnArn.split(':')[4];
-            topicArn = 'arn:aws:sns:' + region + ':' + acctID + ':' + topicName;
+            topicArn = 'arn:' + partition + ':sns:' + region + ':' + acctID + ':' + topicName;
 
             self._serverless.cli.log('Function ARN: ' + fnArn);
             self._serverless.cli.log('Topic ARN: ' + topicArn);

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ module.exports = Class.extend({
             let partition = fnArn.split(':')[1];
             region = fnArn.split(':')[3];
             acctID = fnArn.split(':')[4];
-            topicArn = 'arn' + partition + 'sns:' + region + ':' + acctID + ':' + topicName;
+            topicArn = 'arn:' + partition + ':sns:' + region + ':' + acctID + ':' + topicName;
 
             self._serverless.cli.log('Function ARN: ' + fnArn);
             self._serverless.cli.log('Topic ARN: ' + topicArn);

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ module.exports = Class.extend({
             FunctionName: { 'Fn::GetAtt': [ fnRef, 'Arn' ] },
             Action: 'lambda:InvokeFunction',
             Principal: 'sns.amazonaws.com',
-            SourceArn: { 'Fn::Join': [ ':', [ 'arn:', { 'Ref': 'AWS::Partition' },':sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, topicName ] ] },
+            SourceArn: { 'Fn::Join': [ ':', [ 'arn', { 'Ref': 'AWS::Partition' },'sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, topicName ] ] },
          },
       };
 
@@ -132,7 +132,7 @@ module.exports = Class.extend({
             let partition = fnArn.split(':')[1];
             region = fnArn.split(':')[3];
             acctID = fnArn.split(':')[4];
-            topicArn = 'arn:' + partition + ':sns:' + region + ':' + acctID + ':' + topicName;
+            topicArn = 'arn' + partition + 'sns:' + region + ':' + acctID + ':' + topicName;
 
             self._serverless.cli.log('Function ARN: ' + fnArn);
             self._serverless.cli.log('Topic ARN: ' + topicArn);

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -88,7 +88,7 @@ describe('serverless-plugin-external-sns-events', function() {
                FunctionName: { 'Fn::GetAtt': [ expFunctionName, 'Arn' ] },
                Action: 'lambda:InvokeFunction',
                Principal: 'sns.amazonaws.com',
-               SourceArn: { 'Fn::Join': [ ':', [ 'arn:', { 'Ref': 'AWS::Partition' },':sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, 'cool-Topic' ] ] },
+               SourceArn: { 'Fn::Join': [ ':', [ 'arn', { 'Ref': 'AWS::Partition' },'sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, 'cool-Topic' ] ] },
             },
          };
 

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -88,7 +88,7 @@ describe('serverless-plugin-external-sns-events', function() {
                FunctionName: { 'Fn::GetAtt': [ expFunctionName, 'Arn' ] },
                Action: 'lambda:InvokeFunction',
                Principal: 'sns.amazonaws.com',
-               SourceArn: { 'Fn::Join': [ ':', [ 'arn:aws:sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, 'cool-Topic' ] ] },
+               SourceArn: { 'Fn::Join': [ ':', [ 'arn:', { 'Ref': 'AWS::Partition' },':sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, 'cool-Topic' ] ] },
             },
          };
 


### PR DESCRIPTION
Serverless deployment fails when deploying to a gov-cloud or china region (because these regions use different partition values for the ARNs).

Sample error
```
Serverless: Topic ARN: arn:aws:sns:us-gov-east-1:xxxxxxxx:Device-events-gov
Unhandled rejection ServerlessError: Invalid parameter: TopicArn Reason: A us-gov-east-1 ARN must begin with arn:aws-us-gov, not arn:aws:sns:us-gov-east-1:xxxxxxxx:Device-events-gov
    at /Users/jeremygiberson/gitprojects/device-api-serverless/node_modules/serverless/lib/plugins/aws/provider/awsProvider.js:1058:27
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

