### PR TITLE
feat: make plugin compatible with Serverless v3.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,8 @@ module.exports = Class.extend({
             lifecycleEvents: [ 'unsubscribe' ],
          },
       };
+
+      this._serverless.configSchemaHandler.defineFunctionEvent('aws', 'externalSNS', { type: 'string' });
    },
 
    _loopEvents: function(fn) {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ module.exports = Class.extend({
       this.provider = serverless ? serverless.getProvider('aws') : null;
 
       this.hooks = {
-         'deploy:compileEvents': this._loopEvents.bind(this, this.addEventPermission),
+         'package:compileEvents': this._loopEvents.bind(this, this.addEventPermission),
          'deploy:deploy': this._loopEvents.bind(this, this.subscribeFunction),
          'before:remove:remove': this._loopEvents.bind(this, this.unsubscribeFunction),
          'subscribeExternalSNS:subscribe': this._loopEvents.bind(this, this.subscribeFunction),

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -33,6 +33,9 @@ describe('serverless-plugin-external-sns-events', function() {
          cli: { log: function() {
             return;
          } },
+         configSchemaHandler: {
+            defineFunctionEvent: function() {},
+         },
       };
       return serverless;
    }


### PR DESCRIPTION
The changes in this MR allow this plugin to be used with Serverless 3.x but do not impose any new backwards compatibility constraints:

   * The `package:compileEvents` event has been available since [version 1.12.0](https://github.com/serverless/serverless/releases/tag/v1.12.0).
   * The `defineFunctionEvent` method has been available since [version 1.78.0](https://github.com/serverless/serverless/releases/tag/v1.78.0)